### PR TITLE
Backend chart refactor

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+    "name": "Perceptual Map Tool",
+    "description": "Perceptual maps on python with support for plotting and supplementary data.",
+    "image": "heroku/python",
+    "repository": "https://github.com/nachomaiz/pmap",
+    "keywords": ["pmap", "perceptual map", "correspondence analysis" ]
+}

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ st.set_page_config(
 
 # Cached data and model load for faster interactivity
 @st.cache(allow_output_mutation=True)
-def build_pmap_model(X : pd.DataFrame, supp, n_components : int, n_iter: int) -> pmap.PMAP:
+def build_pmap_model(X : pd.DataFrame, supp: tuple, n_components : int, n_iter: int) -> pmap.PMAP:
     return pmap.PMAP(n_components, n_iter).fit(X, supp)
 
 @st.cache()

--- a/app.py
+++ b/app.py
@@ -142,7 +142,7 @@ if uploaded_file:
     # Plot Perceptual Map
     with plt.style.context(mplparams):
         fig, ax = plt.subplots(figsize=(16,9))
-        model.plot_coordinates(x_component=x_component, y_component=y_component, supp=plot_supp, ax=ax, invert_ax=invert_ax)
+        model.plot_map(x_component=x_component, y_component=y_component, supp=plot_supp, ax=ax, invert_ax=invert_ax)
     ax.grid(False) # force grid off
     st.pyplot(fig)
 

--- a/app.py
+++ b/app.py
@@ -136,7 +136,7 @@ if uploaded_file:
         'ytick.color' : plot_colors[plot_theme]['fg'],
         'ytick.labelcolor' : plot_colors[plot_theme]['fg'],
         'axes.prop_cycle' : cycler.cycler('color',plt.cm.Dark2(range(0,4))),
-        'font.size' : '14.0'
+        'font.size' : '12.0'
     }
 
     # Plot Perceptual Map

--- a/src/pmap.py
+++ b/src/pmap.py
@@ -27,12 +27,15 @@ class PMAP(CA):
         '''Fits PMAP to dataframe, handling supplementary data separately.
 
         Parameters
-        -----------
-        X : dataframe to fit self with
+        ----------
+        X : dataframe to fit PMAP
             This dataframe should have cases by row and attributes by columns. Case labels should be reflected in the index.
         supp : None, tuple
             The number of supplementary rows and/or columns in the data. (supp_rows, supp_cols) Defaults to None.
 
+        Returns
+        -------
+        new_PMAP : PMAP object fitted to X
         '''
         # check X type
         if not isinstance(X, pd.DataFrame):
@@ -79,7 +82,8 @@ class PMAP(CA):
         else:
             return self.column_coordinates(self.supp_cols)
 
-    def plot_supp(self, figsize: tuple = (16,9), ax = None, x_component: int = 0, y_component: int = 1, show_labels: tuple = (True,True), **kwargs):
+    def plot_supp(self, figsize: tuple = (16,9), ax = None, x_component: int = 0, 
+                  y_component: int = 1, show_labels: tuple = (True,True), **kwargs):
         '''Refactoring of plot_coordinates to plot supplementary data'''
 
         self._check_is_fitted()
@@ -90,42 +94,29 @@ class PMAP(CA):
         # Add style
         ax = plot.stylize_axis(ax)
 
-        # Get labels and names
+        # Get labels and names. Can turn this into a generic plotting function to loop over a tuple like (c_row, c_col, s_row, s_col)
         if self.supp[0] > 0:
             row_label, row_names, _, _ = util.make_labels_and_names(self.supp_rows)
             # Plot row principal coordinates (minus supp cols)
-            row_coords = self.fitted_supp_rows
-            ax.scatter(
-                row_coords[x_component],
-                row_coords[y_component],
-                **kwargs,
-                label='Supp ' + row_label
-            )
+            row_x = self.fitted_supp_rows[x_component]
+            row_y = self.fitted_supp_rows[y_component]
+            ax.scatter(row_x, row_y, **kwargs, label = 'Supp ' + row_label)
 
             # Add row labels
             if show_labels[0]:
-                x = row_coords[x_component]
-                y = row_coords[y_component]
-                for xi, yi, label in zip(x, y, row_names):
+                for xi, yi, label in zip(row_x, row_y, row_names):
                     ax.annotate(label, (xi, yi))
         
         if self.supp[1] > 0:
             _, _, col_label, col_names = util.make_labels_and_names(self.supp_cols)
-
             # Plot column principal coordinates (minus supp rows)
-            col_coords = self.fitted_supp_cols
-            ax.scatter(
-                col_coords[x_component],
-                col_coords[y_component],
-                **kwargs,
-                label='Supp ' + col_label
-            )
+            col_x = self.fitted_supp_cols[x_component]
+            col_y = self.fitted_supp_cols[y_component]
+            ax.scatter(col_x, col_y, **kwargs, label='Supp ' + col_label)
 
             # Add column labels
             if show_labels[1]:
-                x = col_coords[x_component]
-                y = col_coords[y_component]
-                for xi, yi, label in zip(x, y, col_names):
+                for xi, yi, label in zip(col_x, col_y, col_names):
                     ax.annotate(label, (xi, yi))
 
         # Legend
@@ -140,8 +131,8 @@ class PMAP(CA):
 
         return ax
 
-    def plot_coordinates(self, figsize = (16,9), ax = None, x_component = 0, y_component = 1,
-                         supp = False, show_labels = (True,True), invert_ax = None, **kwargs):
+    def plot_coordinates(self, figsize: tuple = (16,9), ax = None, x_component: int = 0, y_component: int = 1,
+                         supp = False, show_labels: tuple = (True,True), invert_ax: str = None, **kwargs):
         
         '''Plots perceptual map from trained self. 
 
@@ -190,7 +181,6 @@ class PMAP(CA):
 
         # if 'only', will need to plot into ax not from plot_coordinates, otherwise plot normally and add supp if needed
         if supp == 'only':
-            
             ax = self.plot_supp(figsize=figsize, ax=ax, x_component=x_component, y_component=y_component, show_labels=show_labels, **kwargs)
 
         else:
@@ -220,7 +210,7 @@ class PMAP(CA):
                 ax.invert_xaxis()
                 ax.invert_yaxis()
             else:
-                raise ValueError("invert must be 'x', 'y' or 'b' for both")
+                raise ValueError("invert_ax must be 'x', 'y' or 'b' for both")
 
         return ax
 
@@ -258,7 +248,8 @@ class PMAP(CA):
                               self.column_coordinates(self.core)], 
                               keys=['Rows','Columns'])
     
-    def get_chart_data(self, x_component:int = 0, y_component:int = 1, invert_ax=None) -> pd.DataFrame:
+    def get_chart_data(self, x_component:int = 0, y_component:int = 1, invert_ax: str = None) -> pd.DataFrame:
+        '''Returns two dimensions of multi-indexed fitted data'''
         _d = self.fitted_data[[x_component, y_component]]
         if invert_ax is not None:
             if invert_ax == 'x':

--- a/src/pmap.py
+++ b/src/pmap.py
@@ -277,7 +277,7 @@ class PMAP(CA):
         
         return ax
     
-    def subplots(self, figsize: tuple = (16,9), axes = None, x_component: int = 0,
+    def plot_subplots(self, figsize: tuple = (16,9), axes = None, x_component: int = 0,
                 y_component: int = 1, **kwargs):
         '''Plots each chunk of data into a separate subplot.
         

--- a/src/pmap.py
+++ b/src/pmap.py
@@ -309,7 +309,7 @@ class PMAP(CA):
 
         # Build figure if none is passed
         if axes is None:
-            fig, axes = plt.subplots(nrows=2, ncols=2 if n_plots > 2 else 1, sharex=True, sharey=True, figsize=figsize, constrained_layout=True)
+            fig, axes = plt.subplots(nrows=2 if n_plots > 2 else 1, ncols=2, sharex=True, sharey=True, figsize=figsize, constrained_layout=True)
         
         colors = plt.cm.Dark2(range(0,len(chunks)))
 

--- a/src/pmap.py
+++ b/src/pmap.py
@@ -1,4 +1,3 @@
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import pandas as pd
 from prince.ca import CA
@@ -81,6 +80,10 @@ class PMAP(CA):
             return self.column_coordinates(self.supp_cols.iloc[:-self.supp[0],:])
         else:
             return self.column_coordinates(self.supp_cols)
+
+    @property
+    def fitted_tuple(self) -> tuple:
+        return self.row_coordinates(self.core), self.column_coordinates(self.core), self.fitted_supp_rows, self.fitted_supp_cols
 
     def plot_supp(self, figsize: tuple = (16,9), ax = None, x_component: int = 0, 
                   y_component: int = 1, show_labels: tuple = (True,True), **kwargs):


### PR DESCRIPTION
The pmap module's plotting functions have been refactored and the streamlit app has been updated to reflect the changes:

- Plotting now occurs in loops via the self._plot method to better handle supplementary data. 
	- The property self._fitted_tuple returns a data store tuple to loop over.
	- This will make it a lot easier to expand functionality and improve performance in the future.
	- For now rows and columns will default to being called "Rows" and "Columns". Might change if need arises.
- Plotting is now done through the plot_map method, which requires the same inputs as the previous plot_coordinates.
- New plotting method plot_subplots, which returns a matplotlib figure with each chunk of data (rows, cols, supp rows, supp cols) in a separate chart. Uses new loop method:
![plot_subplots](https://user-images.githubusercontent.com/24781490/123556924-d2ab5c80-d785-11eb-8dcf-b3edc386bcc7.png)